### PR TITLE
 Fixed Update notice.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 plugins {
     id "application"
     id "distribution"
@@ -86,3 +88,24 @@ dependencies {
             "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
     testImplementation 'org.mockito:mockito-inline:3.3.0'
 }
+
+task createProperties(dependsOn: processResources) doLast {
+    // if resources dir is empty we need to create this ourselves
+    new File("$buildDir/resources/main/").mkdirs()
+
+    new File("$buildDir/resources/main/epirus-version.properties").withWriter { w ->
+        Properties p = new Properties()
+        p['version'] = project.version.toString()
+        p['timestamp'] = getTimestamp()
+        p.store w, null
+    }
+}
+
+def getTimestamp() {
+    Date today = new Date()
+    SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S z")
+    df.setTimeZone(TimeZone.getTimeZone("UTC"))
+    return df.format(today)
+}
+
+classes { dependsOn createProperties }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.6.0-SNAPSHOT
+version=1.0.0-SNAPSHOT

--- a/src/main/java/io/epirus/console/Runner.java
+++ b/src/main/java/io/epirus/console/Runner.java
@@ -19,11 +19,11 @@ import io.epirus.console.project.ProjectCreator;
 import io.epirus.console.project.ProjectImporter;
 import io.epirus.console.project.UnitTestCreator;
 import io.epirus.console.update.Updater;
+import io.epirus.console.utils.Version;
 
 import org.web3j.codegen.Console;
 import org.web3j.codegen.SolidityFunctionWrapperGenerator;
 import org.web3j.codegen.TruffleJsonFunctionWrapperGenerator;
-import org.web3j.utils.Version;
 
 import static io.epirus.console.project.ProjectCreator.COMMAND_NEW;
 import static io.epirus.console.project.ProjectImporter.COMMAND_IMPORT;
@@ -105,6 +105,7 @@ public class Runner {
                     Console.exitError(USAGE);
             }
         }
+        config.save();
         Console.exitSuccess();
     }
 }

--- a/src/main/java/io/epirus/console/config/CliConfig.java
+++ b/src/main/java/io/epirus/console/config/CliConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Web3 Labs Ltd.
+ * Copyright 2020 Web3 Labs Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,13 +22,13 @@ import java.util.UUID;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.Expose;
-
-import org.web3j.utils.Version;
+import io.epirus.console.utils.Version;
 
 public class CliConfig {
     private static final Path DEFAULT_EPIRUS_CONFIG_PATH =
             Paths.get(System.getProperty("user.home"), ".epirus", ".config");
-    private static final String servicesURL = "https://internal.services.web3labs.com";
+    private static final String defaultServicesUrl =
+            "https://internal.services.web3labs.com/api/epirus/versions/latest";
 
     public static Path getDefaultEpirusConfigPath() {
         return DEFAULT_EPIRUS_CONFIG_PATH;
@@ -41,7 +41,7 @@ public class CliConfig {
         }
         return new CliConfig(
                 Version.getVersion(),
-                servicesURL,
+                defaultServicesUrl,
                 UUID.randomUUID().toString(),
                 Version.getVersion(),
                 null,

--- a/src/main/java/io/epirus/console/update/Updater.java
+++ b/src/main/java/io/epirus/console/update/Updater.java
@@ -57,10 +57,7 @@ public class Updater {
                         .build();
 
         Request updateCheckRequest =
-                new okhttp3.Request.Builder()
-                        .url("https://internal.services.web3labs.com/api/epirus/versions/latest")
-                        .post(updateBody)
-                        .build();
+                new okhttp3.Request.Builder().url(config.getServicesUrl()).post(updateBody).build();
 
         try {
             Response sendRawResponse = client.newCall(updateCheckRequest).execute();

--- a/src/main/java/io/epirus/console/update/Updater.java
+++ b/src/main/java/io/epirus/console/update/Updater.java
@@ -16,13 +16,12 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.epirus.console.config.CliConfig;
+import io.epirus.console.utils.Version;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
-import org.web3j.utils.Version;
 
 public class Updater {
 
@@ -37,7 +36,11 @@ public class Updater {
         if (config.isUpdateAvailable()) {
             System.out.println(
                     String.format(
-                            "A new Epirus CLI update is available. To update, run: %s",
+                            "Your current Epirus version is: "
+                                    + config.getVersion()
+                                    + ". The latest Version is: "
+                                    + config.getLatestVersion()
+                                    + ". To update, run: %s",
                             config.getUpdatePrompt()));
         }
     }
@@ -55,7 +58,7 @@ public class Updater {
 
         Request updateCheckRequest =
                 new okhttp3.Request.Builder()
-                        .url(String.format("%s/api/versions/latest", config.getServicesUrl()))
+                        .url("https://internal.services.web3labs.com/api/epirus/versions/latest")
                         .post(updateBody)
                         .build();
 

--- a/src/main/java/io/epirus/console/utils/Version.java
+++ b/src/main/java/io/epirus/console/utils/Version.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.epirus.console.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+public class Version {
+
+    private Version() {}
+
+    public static final String DEFAULT = "none";
+
+    private static final String TIMESTAMP = "timestamp";
+    private static final String VERSION = "version";
+
+    public static String getVersion() throws IOException {
+        return loadProperties().getProperty(VERSION);
+    }
+
+    public static String getTimestamp() throws IOException {
+        return loadProperties().getProperty(TIMESTAMP);
+    }
+
+    private static Properties loadProperties() throws IOException {
+        Properties properties = new Properties();
+        File file = new File("resources.properties");
+        System.out.println(file.getAbsolutePath());
+        properties.load(Version.class.getResourceAsStream("/epirus-version.properties"));
+        return properties;
+    }
+}

--- a/src/main/java/io/epirus/console/utils/Version.java
+++ b/src/main/java/io/epirus/console/utils/Version.java
@@ -12,7 +12,6 @@
  */
 package io.epirus.console.utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
@@ -35,9 +34,9 @@ public class Version {
 
     private static Properties loadProperties() throws IOException {
         Properties properties = new Properties();
-        File file = new File("resources.properties");
-        System.out.println(file.getAbsolutePath());
-        properties.load(Version.class.getResourceAsStream("/epirus-version.properties"));
+        properties.load(
+                io.epirus.console.utils.Version.class.getResourceAsStream(
+                        "/epirus-version.properties"));
         return properties;
     }
 }

--- a/src/test/java/io/epirus/console/project/UpdaterTest.java
+++ b/src/test/java/io/epirus/console/project/UpdaterTest.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.gson.Gson;
 import io.epirus.console.config.CliConfig;
 import io.epirus.console.update.Updater;
+import io.epirus.console.utils.Version;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
-
-import org.web3j.utils.Version;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -83,7 +82,7 @@ public class UpdaterTest {
                         Mockito.withSettings()
                                 .useConstructor(
                                         Version.getVersion(),
-                                        "http://localhost:8081",
+                                        "http://localhost:8081/api/epirus/versions/latest",
                                         UUID.randomUUID().toString(),
                                         Version.getVersion(),
                                         null,
@@ -119,14 +118,14 @@ public class UpdaterTest {
                         "{\n"
                                 + "  \"latest\": {\n"
                                 + "    \"version\": \"%s\",\n"
-                                + "    \"install_unix\": \"curl -L get.web3j.io | sh\",\n"
+                                + "    \"install_unix\": \"curl -L get.epirus.io | sh\",\n"
                                 + "    \"install_win\": \"Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/web3j/web3j-installer/master/installer.ps1'))\"\n"
                                 + "  }\n"
                                 + "}",
                         version);
 
         stubFor(
-                post(urlPathMatching("/api/versions/latest"))
+                post(urlPathMatching("/api/epirus/versions/latest"))
                         .willReturn(
                                 aResponse()
                                         .withStatus(200)
@@ -134,7 +133,7 @@ public class UpdaterTest {
                                         .withBody(validUpdateResponse)));
         updater.onlineUpdateCheck();
 
-        verify(postRequestedFor(urlEqualTo("/api/versions/latest")));
+        verify(postRequestedFor(urlEqualTo("/api/epirus/versions/latest")));
         // if the version parameter does not equal config.getVersion, isUpdateAvailable should
         // return true, otherwise it should return false
         assertEquals(!version.equals(config.getVersion()), config.isUpdateAvailable());

--- a/src/test/resources/epirus-version.properties
+++ b/src/test/resources/epirus-version.properties
@@ -1,0 +1,3 @@
+#Fri Mar 27 18:28:04 GMT 2020
+version=1.0.0-SNAPSHOT
+timestamp=2020-03-27 18\:28\:04.682 UTC


### PR DESCRIPTION
Added gradle task to separate epirus cli Version.java
Changed version in gradle.properties to 1.0.0-SNAPSHOT
Replaced Version calls which previously referred to web3j core version.
Changed the Update text.

