### PR TITLE
Generate shadow artifacts for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     if: branch = master OR type = pull_request
   - stage: release github
     if: branch =~ /release/
-    script: "./gradlew check distZip distTar -Pversion=${TRAVIS_BRANCH#'release/'}
+    script: "./gradlew check distZip distTar shadowDistTar shadowDistZip -Pversion=${TRAVIS_BRANCH#'release/'}
       && ./scripts/github-release.sh"
 env:
   global:


### PR DESCRIPTION
In order to let the installer install a shadowJar we need to tell the github release script to generate shadow zip/tar