### PR TITLE
Better wallet handeling and Utility.

### DIFF
--- a/src/main/java/io/epirus/console/Runner.java
+++ b/src/main/java/io/epirus/console/Runner.java
@@ -111,6 +111,9 @@ public class Runner {
                     config.setLoginToken("");
                     System.out.println("Logged out successfully");
                     break;
+                case "accountwallet":
+                    AccountManager.main(new String[] {"accountwallet"});
+                    break;
                 case COMMAND_GENERATE_TESTS:
                     UnitTestCreator.main(tail(args));
                     break;

--- a/src/main/java/io/epirus/console/account/AccountManager.java
+++ b/src/main/java/io/epirus/console/account/AccountManager.java
@@ -56,7 +56,6 @@ public class AccountManager implements Closeable {
         if (args.length == 0) {
             exitError(USAGE);
         }
-
         if (Arrays.asList("create", "login").contains(args[0])) {
             String email = new InteractiveOptions().getEmail();
             AccountManager accountManager = new AccountManager();
@@ -87,6 +86,10 @@ public class AccountManager implements Closeable {
                     config.getLoginToken() != null && config.getLoginToken().length() > 0
                             ? "Status: logged in"
                             : "Status: not logged in");
+        } else if ("accountwallet".equals(args[0])) {
+            if (config.getLoginToken() != null && config.getLoginToken().length() > 0) {
+                AccountUtils.accountDefaultWalletInit();
+            }
         } else {
             exitError(USAGE);
         }

--- a/src/main/java/io/epirus/console/account/AccountUtils.java
+++ b/src/main/java/io/epirus/console/account/AccountUtils.java
@@ -12,9 +12,18 @@
  */
 package io.epirus.console.account;
 
+import java.io.File;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+
 import io.epirus.console.project.InteractiveOptions;
+import io.epirus.console.project.wallet.ProjectWallet;
+import io.epirus.console.project.wallet.ProjectWalletUtils;
 
 import org.web3j.codegen.Console;
+import org.web3j.crypto.CipherException;
 
 public class AccountUtils {
 
@@ -30,6 +39,39 @@ public class AccountUtils {
                 Console.exitError(
                         "Server response did not contain the authentication token required to create an account.");
             }
+        }
+    }
+
+    public static void accountDefaultWalletInit() {
+        InteractiveOptions userInteractiveOptions = new InteractiveOptions();
+        if (!ProjectWalletUtils.userHasGlobalWallet()) {
+            try {
+                ProjectWallet projectWallet =
+                        new ProjectWallet("", ProjectWalletUtils.DEFAULT_WALLET_LOOKUP_PATH);
+                boolean walletWasRenamed =
+                        new File(
+                                        projectWallet.getWalletPath()
+                                                + File.separator
+                                                + projectWallet.getWalletName())
+                                .renameTo(
+                                        new File(
+                                                ProjectWalletUtils.DEFAULT_WALLET_LOOKUP_PATH
+                                                        + File.separator
+                                                        + ProjectWalletUtils.DEFAULT_WALLET_NAME));
+                if (!walletWasRenamed) {
+                    Console.exitError("Could not rename default test wallet.");
+                }
+                System.out.println("Default wallet was created successfully.");
+
+            } catch (NoSuchAlgorithmException
+                    | NoSuchProviderException
+                    | InvalidAlgorithmParameterException
+                    | CipherException
+                    | IOException e) {
+                Console.exitError("Could not create default wallet reason: " + e.getMessage());
+            }
+        } else {
+            System.out.println("Account has default wallet.");
         }
     }
 }

--- a/src/main/java/io/epirus/console/project/AbstractProject.java
+++ b/src/main/java/io/epirus/console/project/AbstractProject.java
@@ -17,10 +17,13 @@ import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.util.Map;
+import java.util.Optional;
 
 import io.epirus.console.project.templates.TemplateProvider;
 import io.epirus.console.project.utils.ProgressCounter;
 import io.epirus.console.project.utils.ProjectUtils;
+import io.epirus.console.project.wallet.ProjectWallet;
 
 import org.web3j.codegen.Console;
 import org.web3j.crypto.CipherException;
@@ -30,7 +33,7 @@ public abstract class AbstractProject<T extends AbstractProject<T>> {
 
     protected final boolean withTests;
     protected final boolean withFatJar;
-    protected final boolean withWallet;
+    protected final Optional<Map> withCredentials;
     protected final boolean withSampleCode;
     protected final String command;
     protected final String solidityImportPath;
@@ -43,14 +46,14 @@ public abstract class AbstractProject<T extends AbstractProject<T>> {
     protected AbstractProject(
             boolean withTests,
             boolean withFatJar,
-            boolean withWallet,
+            Optional<Map> withCredentials,
             boolean withSampleCode,
             String command,
             String solidityImportPath,
             ProjectStructure projectStructure) {
         this.withTests = withTests;
         this.withFatJar = withFatJar;
-        this.withWallet = withWallet;
+        this.withCredentials = withCredentials;
         this.withSampleCode = withSampleCode;
         this.command = command;
         this.solidityImportPath = solidityImportPath;
@@ -146,13 +149,8 @@ public abstract class AbstractProject<T extends AbstractProject<T>> {
         projectStructure.createWrapperDirectory();
     }
 
-    public void createProject()
-            throws IOException, InterruptedException, NoSuchAlgorithmException,
-                    NoSuchProviderException, InvalidAlgorithmParameterException, CipherException {
+    public void createProject() throws IOException, InterruptedException {
         generateTopLevelDirectories(projectStructure);
-        if (withWallet) {
-            generateWallet();
-        }
         getTemplateProvider().generateFiles(projectStructure);
         progressCounter.processing("Creating " + projectStructure.projectName);
         buildGradleProject(projectStructure.getProjectRoot());

--- a/src/main/java/io/epirus/console/project/AbstractProjectBuilder.java
+++ b/src/main/java/io/epirus/console/project/AbstractProjectBuilder.java
@@ -12,11 +12,14 @@
  */
 package io.epirus.console.project;
 
+import java.util.Map;
+import java.util.Optional;
+
 public abstract class AbstractProjectBuilder<T extends AbstractProjectBuilder<T>> {
     private T builder;
 
     protected String solidityImportPath;
-    protected boolean withWallet;
+    protected Optional<Map> withCredentials;
     protected boolean withTests;
     protected String projectName;
     protected String packageName;
@@ -35,8 +38,8 @@ public abstract class AbstractProjectBuilder<T extends AbstractProjectBuilder<T>
         return builder;
     }
 
-    public T withWalletProvider(boolean withWalletProvider) {
-        builder.withWallet = withWalletProvider;
+    public T withCredentials(Optional<Map> withCredentials) {
+        builder.withCredentials = withCredentials;
         return this.builder;
     }
 

--- a/src/main/java/io/epirus/console/project/Project.java
+++ b/src/main/java/io/epirus/console/project/Project.java
@@ -17,6 +17,8 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 
+import io.epirus.console.project.wallet.ProjectWallet;
+
 import org.web3j.crypto.CipherException;
 
 public interface Project {

--- a/src/main/java/io/epirus/console/project/ProjectCreator.java
+++ b/src/main/java/io/epirus/console/project/ProjectCreator.java
@@ -18,6 +18,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.diogonunes.jcdp.color.ColoredPrinter;
@@ -69,6 +70,7 @@ public class ProjectCreator {
     private static String[] getValues(String[] args, List<String> stringOptions)
             throws IOException {
         String projectName;
+        Map<String, String> walletCredentials;
         if (args.length == 0) {
             InteractiveOptions interactiveOptions = new InteractiveOptions();
             stringOptions.add("-n");
@@ -76,6 +78,11 @@ public class ProjectCreator {
             stringOptions.add(projectName);
             stringOptions.add("-p");
             stringOptions.add(interactiveOptions.getPackageName());
+            walletCredentials = interactiveOptions.getWalletLocation();
+            stringOptions.add("-w");
+            stringOptions.add(walletCredentials.get("path"));
+            stringOptions.add("-k");
+            stringOptions.add(walletCredentials.get("password"));
             interactiveOptions
                     .getProjectDestination(projectName)
                     .ifPresent(
@@ -92,7 +99,7 @@ public class ProjectCreator {
     public void generateJava(
             boolean withTests,
             Optional<File> solidityFile,
-            boolean withWalletProvider,
+            Optional<Map> withCredentials,
             boolean withFatJar,
             boolean withSampleCode,
             String command) {
@@ -103,7 +110,7 @@ public class ProjectCreator {
                             .withRootDirectory(this.root)
                             .withPackageName(this.packageName)
                             .withTests(withTests)
-                            .withWalletProvider(withWalletProvider)
+                            .withCredentials(withCredentials)
                             .withCommand(command)
                             .withSampleCode(withSampleCode)
                             .withFatJar(withFatJar);
@@ -121,7 +128,7 @@ public class ProjectCreator {
     public void generateKotlin(
             boolean withTests,
             Optional<File> solidityFile,
-            boolean withWalletProvider,
+            Optional<Map> withCredentials,
             boolean withFatJar,
             boolean withSampleCode,
             String command) {
@@ -132,7 +139,7 @@ public class ProjectCreator {
                             .withRootDirectory(this.root)
                             .withPackageName(this.packageName)
                             .withTests(withTests)
-                            .withWalletProvider(withWalletProvider)
+                            .withCredentials(withCredentials)
                             .withCommand(command)
                             .withSampleCode(withSampleCode)
                             .withFatJar(withFatJar);

--- a/src/main/java/io/epirus/console/project/ProjectCreatorCLIRunner.java
+++ b/src/main/java/io/epirus/console/project/ProjectCreatorCLIRunner.java
@@ -23,11 +23,10 @@ import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
 public abstract class ProjectCreatorCLIRunner implements Runnable {
     @CommandLine.Option(
-            names = {"-o", "--output-dir"},
-            description = "Destination base directory.",
-            required = false,
-            showDefaultValue = ALWAYS)
-    public String outputDir = System.getProperty("user.dir");
+            names = {"-n", "--project-name"},
+            description = "Project name.",
+            required = true)
+    public String projectName;
 
     @CommandLine.Option(
             names = {"-p", "--package"},
@@ -36,10 +35,11 @@ public abstract class ProjectCreatorCLIRunner implements Runnable {
     public String packageName;
 
     @CommandLine.Option(
-            names = {"-n", "--project-name"},
-            description = "Project name.",
-            required = true)
-    public String projectName;
+            names = {"-o", "--output-dir"},
+            description = "Destination base directory.",
+            required = false,
+            showDefaultValue = ALWAYS)
+    public String outputDir = System.getProperty("user.dir");
 
     @Override
     public void run() {
@@ -59,7 +59,7 @@ public abstract class ProjectCreatorCLIRunner implements Runnable {
 
     protected abstract void createProject();
 
-    boolean inputIsValid(String... requiredArgs) {
+    private boolean inputIsValid(String... requiredArgs) {
         return InputVerifier.requiredArgsAreNotEmpty(requiredArgs)
                 && InputVerifier.classNameIsValid(projectName)
                 && InputVerifier.packageNameIsValid(packageName);

--- a/src/main/java/io/epirus/console/project/ProjectImporter.java
+++ b/src/main/java/io/epirus/console/project/ProjectImporter.java
@@ -53,6 +53,7 @@ public class ProjectImporter extends ProjectCreator {
             stringOptions.add(interactiveOptions.getPackageName());
             stringOptions.add("-s");
             stringOptions.add(interactiveOptions.getSolidityProjectPath());
+
             interactiveOptions
                     .getProjectDestination(projectName)
                     .ifPresent(

--- a/src/main/java/io/epirus/console/project/java/JavaBuilder.java
+++ b/src/main/java/io/epirus/console/project/java/JavaBuilder.java
@@ -35,7 +35,7 @@ public class JavaBuilder extends AbstractProjectBuilder<JavaBuilder> implements 
         return new JavaProject(
                 withTests,
                 withFatJar,
-                withWallet,
+                withCredentials,
                 withSampleCode,
                 command,
                 solidityImportPath,

--- a/src/main/java/io/epirus/console/project/java/JavaProject.java
+++ b/src/main/java/io/epirus/console/project/java/JavaProject.java
@@ -13,6 +13,8 @@
 package io.epirus.console.project.java;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 
 import io.epirus.console.project.AbstractProject;
 import io.epirus.console.project.Project;
@@ -28,7 +30,7 @@ public class JavaProject extends AbstractProject<JavaProject> implements Project
     protected JavaProject(
             boolean withTests,
             boolean withFatJar,
-            boolean withWallet,
+            Optional<Map> withCredentials,
             boolean withSampleCode,
             String command,
             String solidityImportPath,
@@ -36,7 +38,7 @@ public class JavaProject extends AbstractProject<JavaProject> implements Project
         super(
                 withTests,
                 withFatJar,
-                withWallet,
+                withCredentials,
                 withSampleCode,
                 command,
                 solidityImportPath,
@@ -66,10 +68,10 @@ public class JavaProject extends AbstractProject<JavaProject> implements Project
                         .withWrapperGradleSettings("gradlew-wrapper.properties.template")
                         .withGradlewWrapperJar("gradle-wrapper.jar");
 
-        if (projectWallet != null) {
+        if (withCredentials.isPresent()) {
 
-            templateBuilder.withWalletNameReplacement(projectWallet.getWalletName());
-            templateBuilder.withPasswordFileName(projectWallet.getPasswordFileName());
+            templateBuilder.withWalletNameReplacement((String) withCredentials.get().get("path"));
+            templateBuilder.withPasswordFileName((String) withCredentials.get().get("password"));
         }
         if (command.equals("new")) {
             templateBuilder

--- a/src/main/java/io/epirus/console/project/java/JavaProjectCreatorCLIRunner.java
+++ b/src/main/java/io/epirus/console/project/java/JavaProjectCreatorCLIRunner.java
@@ -12,20 +12,42 @@
  */
 package io.epirus.console.project.java;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import io.epirus.console.project.ProjectCreator;
 import io.epirus.console.project.ProjectCreatorCLIRunner;
-import picocli.CommandLine.Command;
+import picocli.CommandLine;
 
-import static io.epirus.console.project.ProjectCreator.COMMAND_JAVA;
 import static io.epirus.console.project.ProjectCreator.COMMAND_NEW;
+import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
-@Command(name = COMMAND_JAVA, mixinStandardHelpOptions = true, version = "4.0", sortOptions = false)
 public class JavaProjectCreatorCLIRunner extends ProjectCreatorCLIRunner {
+    @CommandLine.Option(
+            names = {"-w", "--wallet-path"},
+            description = "Path to your wallet file",
+            required = true)
+    public String walletPath;
+
+    @CommandLine.Option(
+            names = {"-k", "--wallet-password"},
+            description = "Wallet password",
+            required = true,
+            showDefaultValue = ALWAYS)
+    public String walletPassword;
 
     protected void createProject() {
+        Map<String, String> walletCredentials = new HashMap<>();
+        walletCredentials.put("path", walletPath);
+        walletCredentials.put("password", walletPassword);
         new ProjectCreator(outputDir, packageName, projectName)
-                .generateJava(true, Optional.empty(), true, true, true, COMMAND_NEW);
+                .generateJava(
+                        true,
+                        Optional.empty(),
+                        Optional.of(walletCredentials),
+                        true,
+                        true,
+                        COMMAND_NEW);
     }
 }

--- a/src/main/java/io/epirus/console/project/java/JavaProjectImporterCLIRunner.java
+++ b/src/main/java/io/epirus/console/project/java/JavaProjectImporterCLIRunner.java
@@ -15,6 +15,7 @@ package io.epirus.console.project.java;
 import java.io.File;
 import java.util.Optional;
 
+import io.epirus.console.project.ProjectCreatorCLIRunner;
 import io.epirus.console.project.ProjectImporter;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -23,7 +24,7 @@ import static io.epirus.console.project.ProjectImporter.COMMAND_IMPORT;
 import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
 @Command(name = COMMAND_IMPORT)
-public class JavaProjectImporterCLIRunner extends JavaProjectCreatorCLIRunner {
+public class JavaProjectImporterCLIRunner extends ProjectCreatorCLIRunner {
     @Option(
             names = {"-s", "--solidity-path"},
             description = "Path to solidity file/folder",
@@ -42,7 +43,7 @@ public class JavaProjectImporterCLIRunner extends JavaProjectCreatorCLIRunner {
                 .generateJava(
                         generateTests,
                         Optional.of(new File(solidityImportPath)),
-                        true,
+                        Optional.empty(),
                         false,
                         false,
                         COMMAND_IMPORT);

--- a/src/main/java/io/epirus/console/project/kotlin/KotlinBuilder.java
+++ b/src/main/java/io/epirus/console/project/kotlin/KotlinBuilder.java
@@ -30,7 +30,7 @@ public class KotlinBuilder extends AbstractProjectBuilder<KotlinBuilder> impleme
         return new KotlinProject(
                 withTests,
                 withFatJar,
-                withWallet,
+                withCredentials,
                 withSampleCode,
                 command,
                 solidityImportPath,

--- a/src/main/java/io/epirus/console/project/kotlin/KotlinProject.java
+++ b/src/main/java/io/epirus/console/project/kotlin/KotlinProject.java
@@ -16,16 +16,18 @@ import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.util.Map;
+import java.util.Optional;
 
 import io.epirus.console.project.AbstractProject;
 import io.epirus.console.project.Project;
 import io.epirus.console.project.ProjectStructure;
-import io.epirus.console.project.ProjectWallet;
 import io.epirus.console.project.ProjectWriter;
 import io.epirus.console.project.UnitTestCreator;
 import io.epirus.console.project.templates.kotlin.KotlinTemplateBuilder;
 import io.epirus.console.project.templates.kotlin.KotlinTemplateProvider;
 import io.epirus.console.project.utils.ProjectUtils;
+import io.epirus.console.project.wallet.ProjectWallet;
 
 import org.web3j.commons.JavaVersion;
 import org.web3j.crypto.CipherException;
@@ -35,7 +37,7 @@ public class KotlinProject extends AbstractProject<KotlinProject> implements Pro
     protected KotlinProject(
             boolean withTests,
             boolean withFatJar,
-            boolean withWallet,
+            Optional<Map> withCredentials,
             boolean withSampleCode,
             String command,
             String solidityImportPath,
@@ -43,7 +45,7 @@ public class KotlinProject extends AbstractProject<KotlinProject> implements Pro
         super(
                 withTests,
                 withFatJar,
-                withWallet,
+                withCredentials,
                 withSampleCode,
                 command,
                 solidityImportPath,
@@ -93,9 +95,9 @@ public class KotlinProject extends AbstractProject<KotlinProject> implements Pro
                         .withWrapperGradleSettings("gradlew-wrapper.properties.template")
                         .withGradlewWrapperJar("gradle-wrapper.jar");
 
-        if (projectWallet != null) {
-            templateBuilder.withWalletNameReplacement(projectWallet.getWalletName());
-            templateBuilder.withPasswordFileName(projectWallet.getPasswordFileName());
+        if (withCredentials.isPresent()) {
+            templateBuilder.withWalletNameReplacement((String) withCredentials.get().get("path"));
+            templateBuilder.withPasswordFileName((String) withCredentials.get().get("password"));
         }
         if (command.equals("new")) {
             templateBuilder

--- a/src/main/java/io/epirus/console/project/kotlin/KotlinProjectCreatorCLIRunner.java
+++ b/src/main/java/io/epirus/console/project/kotlin/KotlinProjectCreatorCLIRunner.java
@@ -12,6 +12,8 @@
  */
 package io.epirus.console.project.kotlin;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import io.epirus.console.project.ProjectCreator;
@@ -20,6 +22,7 @@ import picocli.CommandLine;
 
 import static io.epirus.console.project.ProjectCreator.COMMAND_KOTLIN;
 import static io.epirus.console.project.ProjectCreator.COMMAND_NEW;
+import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
 @CommandLine.Command(
         name = COMMAND_KOTLIN,
@@ -27,8 +30,30 @@ import static io.epirus.console.project.ProjectCreator.COMMAND_NEW;
         version = "4.0",
         sortOptions = false)
 public class KotlinProjectCreatorCLIRunner extends ProjectCreatorCLIRunner {
+    @CommandLine.Option(
+            names = {"-w", "--wallet-path"},
+            description = "Path to your wallet file",
+            required = true)
+    public String walletPath;
+
+    @CommandLine.Option(
+            names = {"-k", "--wallet-password"},
+            description = "Wallet password",
+            required = true,
+            showDefaultValue = ALWAYS)
+    public String walletPassword;
+
     protected void createProject() {
+        Map<String, String> walletCredentials = new HashMap<>();
+        walletCredentials.put("path", walletPath);
+        walletCredentials.put("password", walletPassword);
         new ProjectCreator(outputDir, packageName, projectName)
-                .generateKotlin(true, Optional.empty(), true, true, true, COMMAND_NEW);
+                .generateKotlin(
+                        true,
+                        Optional.empty(),
+                        Optional.of(walletCredentials),
+                        true,
+                        true,
+                        COMMAND_NEW);
     }
 }

--- a/src/main/java/io/epirus/console/project/kotlin/KotlinProjectImporterCLIRunner.java
+++ b/src/main/java/io/epirus/console/project/kotlin/KotlinProjectImporterCLIRunner.java
@@ -41,7 +41,7 @@ public class KotlinProjectImporterCLIRunner extends KotlinProjectCreatorCLIRunne
                 .generateKotlin(
                         generateTests,
                         Optional.of(new File(solidityImportPath)),
-                        true,
+                        Optional.empty(),
                         false,
                         false,
                         COMMAND_IMPORT);

--- a/src/main/java/io/epirus/console/project/wallet/ProjectWallet.java
+++ b/src/main/java/io/epirus/console/project/wallet/ProjectWallet.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.epirus.console.project;
+package io.epirus.console.project.wallet;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +56,10 @@ public class ProjectWallet {
 
     public String getWalletAddress() {
         return prefixWalletAddress();
+    }
+
+    public String getWalletPath() {
+        return this.walletPath;
     }
 
     private String prefixWalletAddress() {

--- a/src/main/java/io/epirus/console/project/wallet/ProjectWalletUtils.java
+++ b/src/main/java/io/epirus/console/project/wallet/ProjectWalletUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.epirus.console.project.wallet;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.io.File.separator;
+
+public class ProjectWalletUtils {
+
+    public static final String DEFAULT_WALLET_LOOKUP_PATH =
+            System.getProperty("user.home") + separator + ".epirus" + separator + "keystore";
+    public static final String DEFAULT_WALLET_NAME = "TEST_WALLET.json";
+    private final String customWalletPath;
+    private List<String> customWallets;
+
+    public ProjectWalletUtils(String walletPath) {
+        this.customWalletPath = walletPath;
+    }
+
+    public ProjectWalletUtils() {
+        this.customWalletPath = DEFAULT_WALLET_LOOKUP_PATH;
+    }
+
+    public List<String> getListOfGlobalWallets() {
+        try {
+            return Files.walk(Paths.get(customWalletPath))
+                    .map(Path::toString)
+                    .filter(f -> f.endsWith("json"))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return Collections.emptyList();
+    }
+
+    public boolean userHasGlobalWallets() {
+        customWallets = getListOfGlobalWallets();
+        return !customWallets.isEmpty();
+    }
+
+    public static boolean userHasGlobalWallet() {
+        return new File(DEFAULT_WALLET_LOOKUP_PATH + separator + DEFAULT_WALLET_NAME).exists();
+    }
+}

--- a/src/main/resources/Java.template
+++ b/src/main/resources/Java.template
@@ -30,25 +30,13 @@ public class <project_name> {
     public static void main(String[] args) throws Exception {
         try {
             ((ch.qos.logback.classic.Logger) (log)).setLevel(Level.ERROR);
-            Credentials credentials = loadCredentials("<wallet_name>");
+            Credentials credentials = WalletUtils.loadCredentials("<password_file_name>","<wallet_name>");
             Web3j web3j = getDeployWeb3j();
             HelloWorld helloWorld = deployHelloWorld(web3j, credentials, new StaticGasProvider(DefaultGasProvider.GAS_LIMIT, BigInteger.valueOf(7500000L)));
             callGreetMethod(helloWorld);
         } catch (Exception e) {
             log.info(e.getMessage());
         }
-    }
-
-    private static Credentials loadCredentials(String walletName) throws IOException, CipherException {
-        String pathToProjectResources = String.join(File.separator, System.getProperty("user.dir"), "src", "test", "resources", "wallet");
-        String pathToWallet = String.join(File.separator, pathToProjectResources, walletName);
-        String pathToWalletPasswordFile = String.join(File.separator, pathToProjectResources, "<password_file_name>");
-        File file = new File(pathToWalletPasswordFile);
-        log.info("Reading wallet password from resources.");
-        String password = new String(Files.readAllBytes(Paths.get(file.toURI())));
-        log.info("Loading wallet file: " + walletName + " from resources.");
-        log.info("Creating credentials from wallet.");
-        return WalletUtils.loadCredentials(password, new File(pathToWallet));
     }
 
     private static Web3j getDeployWeb3j() throws Exception {

--- a/src/main/resources/Kotlin.template
+++ b/src/main/resources/Kotlin.template
@@ -38,36 +38,12 @@ class <project_name> {
     fun start(args: Array<String>) {
         log as ch.qos.logback.classic.Logger
         log.level = Level.ERROR
-        val credentials: Credentials? = loadCredentials("<wallet_name>")
+        val credentials: Credentials? = WalletUtils.loadCredentials("<password_file_name>", "<wallet_name>")
         val web3j: Web3j? = getDeployWeb3j()
         val helloWorld: HelloWorld? = deployHelloWorld(web3j, credentials, StaticGasProvider(DefaultGasProvider.GAS_PRICE, BigInteger.valueOf(7500000L)))
         callGreetMethod(helloWorld)
     }
 
-    @Throws(IOException::class, CipherException::class)
-    private fun loadCredentials(walletName: String): Credentials? {
-        val pathToProjectResources = java.lang.String.join(
-                File.separator,
-                System.getProperty("user.dir"),
-                "src",
-                "test",
-                "resources",
-                "wallet"
-        )
-        val pathToWallet =
-                java.lang.String.join(File.separator, pathToProjectResources, walletName)
-        val pathToWalletPasswordFile = java.lang.String.join(
-                File.separator,
-                pathToProjectResources,
-                "<password_file_name>"
-        )
-        val file = File(pathToWalletPasswordFile)
-        log.info("Reading wallet password from resources.")
-        val password = String(Files.readAllBytes(Paths.get(file.toURI())))
-        log.info("Loading wallet file: $walletName from resources.")
-        log.info("Creating credentials from wallet.")
-        return WalletUtils.loadCredentials(password, File(pathToWallet))
-    }
 
     private fun getDeployWeb3j(): Web3j {
         val nodeUrl = System.getenv().getOrDefault(NODE_URL, System.getProperty(NODE_URL))


### PR DESCRIPTION
The purpose of this PR is to introduce a better way of working with wallets for epirus-cli and new projects. 

Currently, each project is generated with a unique wallet and that is not ideal.
The idea is to store the wallets in a single location and categorize them based on the test network they are going to be used.

Managing wallets in a single directory or perhaps keeping a path reference in the account configuration could increase ease of access.
Furthermore,  the user could top-up the default wallet balance using the command line with a command such as `epirus top-up rinkeby`  that would detect the wallet and automatically top the user up. 


This PR is in progress. 
Some of the changes will be deleted.