### PR TITLE
Fixes epirus deployer

### DIFF
--- a/src/main/java/io/epirus/console/deploy/DeployCommand.java
+++ b/src/main/java/io/epirus/console/deploy/DeployCommand.java
@@ -211,6 +211,12 @@ public class DeployCommand implements Runnable {
     private void executeProcess(File workingDir, String[] command) throws Exception {
         ProcessBuilder processBuilder = new ProcessBuilder(command);
         processBuilder.environment().put("DEPLOY_NETWORK", network.getNetworkName());
+        processBuilder
+                .environment()
+                .putIfAbsent(
+                        "EPIRUS_WALLET",
+                        walletPath.isEmpty() ? config.getDefaultWalletPath() : walletPath);
+
         int exitCode =
                 processBuilder
                         .directory(workingDir)


### PR DESCRIPTION
Epirus deploy was broken because the templates now check "EPIRUS_WALLET" for the wallet file. Although the Dockerizes sets this variable, the Deploy does not by default, so we get an NPE in the created app when deploying.