### PR TITLE
Adds New command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ task generateVersionProperties {
     doLast {
         new File(generatedResources).mkdirs()
         def generated = new File(generatedResources, "version.properties")
-        generated.write("version=$web3jOpenApiVersion\n")
+        generated.write("version=$rootProject.version\n")
         generated.append("timestamp=${System.currentTimeMillis()}\n")
     }
 }

--- a/src/main/kotlin/io.epirus.console/openapi/AbstractCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/AbstractCommand.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.epirus.console.openapi
+
+import org.web3j.openapi.console.options.ProjectOptions
+import picocli.CommandLine
+import java.io.File
+import java.nio.file.Path
+
+abstract class AbstractCommand {
+
+    @CommandLine.Spec
+    protected lateinit var spec: CommandLine.Model.CommandSpec
+
+    @CommandLine.Option(
+            names = ["-o", "--output"],
+            description = ["project output directory."],
+            defaultValue = "."
+    )
+    protected lateinit var outputDirectory: File
+
+    @CommandLine.Option(
+            names = ["-a", "--abi"],
+            description = ["input ABI files and folders."],
+            arity = "1..*",
+            required = true
+    )
+    protected lateinit var abis: List<File>
+
+    @CommandLine.Option(
+            names = ["-b", "--bin"],
+            description = ["input BIN files and folders."],
+            arity = "1..*",
+            required = true
+    )
+    protected lateinit var bins: List<File>
+
+    @CommandLine.Mixin
+    protected val projectOptions = ProjectOptions()
+
+    @CommandLine.Option(
+            names = ["-p", "--package-name"],
+            description = ["generated package name."],
+            required = true
+    )
+    protected lateinit var packageName: String
+
+    @CommandLine.Option(
+            names = ["--dev"],
+            description = ["not delete the failed build files."],
+            defaultValue = "false"
+    )
+    protected var dev: Boolean = false
+
+    @CommandLine.Option(
+            names = ["--address-length"],
+            description = ["specify the address length."],
+            defaultValue = "20"
+    )
+    protected var addressLength: Int = 20
+
+    fun call(): Int {
+        val projectFolder = Path.of(
+                outputDirectory.canonicalPath,
+                projectOptions.projectName
+        ).toFile().apply {
+            deleteRecursively()
+            mkdirs()
+        }
+
+        return try {
+            generate(projectFolder)
+            CommandLine.ExitCode.OK
+        } catch (e: Exception) {
+            if (!dev) projectFolder.deleteOnExit() // FIXME project doesn't get deleted when there is an exception, try messing with the Mustache templates to reproduce
+            e.printStackTrace()
+            CommandLine.ExitCode.SOFTWARE
+        }
+    }
+
+    abstract fun generate(projectFolder: File)
+}

--- a/src/main/kotlin/io.epirus.console/openapi/AbstractCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/AbstractCommand.kt
@@ -19,9 +19,6 @@ import java.nio.file.Path
 
 abstract class AbstractCommand {
 
-    @CommandLine.Spec
-    protected lateinit var spec: CommandLine.Model.CommandSpec
-
     @CommandLine.Option(
             names = ["-o", "--output"],
             description = ["project output directory."],

--- a/src/main/kotlin/io.epirus.console/openapi/AbstractCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/AbstractCommand.kt
@@ -19,6 +19,9 @@ import java.nio.file.Path
 
 abstract class AbstractCommand {
 
+    @CommandLine.Spec
+    protected lateinit var spec: CommandLine.Model.CommandSpec
+
     @CommandLine.Option(
             names = ["-o", "--output"],
             description = ["project output directory."],

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -12,19 +12,38 @@
  */
 package io.epirus.console.openapi
 
+import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
+import org.web3j.openapi.console.options.ProjectOptions
+import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
 import picocli.CommandLine.Command
+import picocli.CommandLine.ExitCode
+import picocli.CommandLine.Mixin
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Option
+import picocli.CommandLine.Spec
 import java.io.File
+import java.nio.file.Paths
 import java.util.concurrent.Callable
 
 @Command(
-    name = "generate",
-    showDefaultValues = true,
-    description = ["Generates the Web3j OpenAPI Kotlin code."]
-)
-class GenerateCommand : AbstractCommand(), Callable<Int> {
+        name = "generate",
+        description = ["Generate a new OpenAPI Kotlin code"],
+        showDefaultValues = true,
+        abbreviateSynopsis = true,
+        mixinStandardHelpOptions = true,
+        versionProvider = EpirusVersionProvider::class,
+        synopsisHeading = "%n",
+        descriptionHeading = "%nDescription:%n%n",
+        optionListHeading = "%nOptions:%n",
+        footerHeading = "%n",
+        footer = ["Epirus CLI is licensed under the Apache License 2.0"])
+class GenerateCommand : Callable<Int> {
+
+    @Spec
+    private lateinit var spec: CommandSpec
 
     override fun generate(projectFolder: File) {
 

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -16,16 +16,10 @@ import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
-import org.web3j.openapi.console.options.ProjectOptions
-import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
 import picocli.CommandLine.Command
-import picocli.CommandLine.ExitCode
-import picocli.CommandLine.Mixin
 import picocli.CommandLine.Model.CommandSpec
-import picocli.CommandLine.Option
 import picocli.CommandLine.Spec
 import java.io.File
-import java.nio.file.Paths
 import java.util.concurrent.Callable
 
 @Command(
@@ -40,10 +34,10 @@ import java.util.concurrent.Callable
         optionListHeading = "%nOptions:%n",
         footerHeading = "%n",
         footer = ["Epirus CLI is licensed under the Apache License 2.0"])
-class GenerateCommand : Callable<Int> {
+class GenerateCommand : Callable<Int>, AbstractCommand() {
 
     @Spec
-    private lateinit var spec: CommandSpec
+    lateinit var spec: CommandSpec
 
     override fun generate(projectFolder: File) {
 

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -53,8 +53,7 @@ class GenerateCommand : Callable<Int> {
             outputDir = projectFolder.path,
             contracts = loadContractConfigurations(abis, bins),
             addressLength = addressLength,
-            contextPath = projectOptions.contextPath?.removeSuffix("/") ?: projectOptions.projectName,
-            version = OpenApiCommand.VersionProvider.versionName
+            contextPath = projectOptions.contextPath?.removeSuffix("/") ?: projectOptions.projectName
         )
 
         GenerateOpenApi(generatorConfiguration).apply {

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -34,10 +34,7 @@ import java.util.concurrent.Callable
         optionListHeading = "%nOptions:%n",
         footerHeading = "%n",
         footer = ["Epirus CLI is licensed under the Apache License 2.0"])
-class GenerateCommand : Callable<Int> {
-
-    @Spec
-    private lateinit var spec: CommandSpec
+class GenerateCommand : Callable<Int>, AbstractCommand() {
 
     override fun generate(projectFolder: File) {
 

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -17,8 +17,6 @@ import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
 import picocli.CommandLine.Command
-import picocli.CommandLine.Model.CommandSpec
-import picocli.CommandLine.Spec
 import java.io.File
 import java.util.concurrent.Callable
 

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -12,32 +12,19 @@
  */
 package io.epirus.console.openapi
 
-import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
 import picocli.CommandLine.Command
-import picocli.CommandLine.Model.CommandSpec
-import picocli.CommandLine.Spec
 import java.io.File
 import java.util.concurrent.Callable
 
 @Command(
-        name = "generate",
-        description = ["Generate a new OpenAPI Kotlin code"],
-        showDefaultValues = true,
-        abbreviateSynopsis = true,
-        mixinStandardHelpOptions = true,
-        versionProvider = EpirusVersionProvider::class,
-        synopsisHeading = "%n",
-        descriptionHeading = "%nDescription:%n%n",
-        optionListHeading = "%nOptions:%n",
-        footerHeading = "%n",
-        footer = ["Epirus CLI is licensed under the Apache License 2.0"])
-class GenerateCommand : Callable<Int>, AbstractCommand() {
-
-    @Spec
-    lateinit var spec: CommandSpec
+    name = "generate",
+    showDefaultValues = true,
+    description = ["Generates the Web3j OpenAPI Kotlin code."]
+)
+class GenerateCommand : AbstractCommand(), Callable<Int> {
 
     override fun generate(projectFolder: File) {
 

--- a/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/GenerateCommand.kt
@@ -16,16 +16,10 @@ import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
-import org.web3j.openapi.console.options.ProjectOptions
-import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
 import picocli.CommandLine.Command
-import picocli.CommandLine.ExitCode
-import picocli.CommandLine.Mixin
 import picocli.CommandLine.Model.CommandSpec
-import picocli.CommandLine.Option
 import picocli.CommandLine.Spec
 import java.io.File
-import java.nio.file.Paths
 import java.util.concurrent.Callable
 
 @Command(

--- a/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
@@ -12,10 +12,12 @@
  */
 package io.epirus.console.openapi
 
+import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
 import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
+import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
 import java.util.concurrent.Callable
@@ -23,9 +25,20 @@ import java.util.concurrent.Callable
 @Command(
         name = "new",
         showDefaultValues = true,
-        description = ["Generates a whole Web3j OpenAPI project."]
+        description = ["Generates a whole OpenAPI project."],
+        abbreviateSynopsis = true,
+        mixinStandardHelpOptions = true,
+        versionProvider = EpirusVersionProvider::class,
+        synopsisHeading = "%n",
+        descriptionHeading = "%nDescription:%n%n",
+        optionListHeading = "%nOptions:%n",
+        footerHeading = "%n",
+        footer = ["Epirus CLI is licensed under the Apache License 2.0"]
 )
 class NewCommand : AbstractCommand(), Callable<Int> {
+
+    @CommandLine.Spec
+    lateinit var spec: CommandLine.Model.CommandSpec
 
     override fun generate(projectFolder: File) {
 

--- a/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.epirus.console.openapi
+
+import org.web3j.openapi.codegen.GenerateOpenApi
+import org.web3j.openapi.codegen.config.GeneratorConfiguration
+import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
+import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
+import picocli.CommandLine.Command
+import java.io.File
+import java.util.concurrent.Callable
+
+@Command(
+        name = "new",
+        showDefaultValues = true,
+        description = ["Generates a whole Web3j OpenAPI project."]
+)
+class NewCommand : AbstractCommand(), Callable<Int> {
+
+    override fun generate(projectFolder: File) {
+
+        val generatorConfiguration = GeneratorConfiguration(
+                projectName = projectOptions.projectName,
+                packageName = packageName,
+                outputDir = projectFolder.path,
+                contracts = loadContractConfigurations(abis, bins),
+                addressLength = addressLength,
+                contextPath = projectOptions.contextPath?.removeSuffix("/") ?: projectOptions.projectName,
+                version = OpenApiCommand.VersionProvider.versionName
+        )
+
+        GenerateOpenApi(generatorConfiguration).generateAll()
+        runGradleTask(projectFolder, "completeSwaggerUiGeneration", "Generating SwaggerUI...")
+
+        println("Done.")
+    }
+}

--- a/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
@@ -17,7 +17,6 @@ import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
 import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
-import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
 import java.util.concurrent.Callable

--- a/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
@@ -12,12 +12,10 @@
  */
 package io.epirus.console.openapi
 
-import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
 import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
-import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
 import java.util.concurrent.Callable
@@ -25,20 +23,9 @@ import java.util.concurrent.Callable
 @Command(
         name = "new",
         showDefaultValues = true,
-        description = ["Generates a whole OpenAPI project."],
-        abbreviateSynopsis = true,
-        mixinStandardHelpOptions = true,
-        versionProvider = EpirusVersionProvider::class,
-        synopsisHeading = "%n",
-        descriptionHeading = "%nDescription:%n%n",
-        optionListHeading = "%nOptions:%n",
-        footerHeading = "%n",
-        footer = ["Epirus CLI is licensed under the Apache License 2.0"]
+        description = ["Generates a whole Web3j OpenAPI project."]
 )
 class NewCommand : AbstractCommand(), Callable<Int> {
-
-    @CommandLine.Spec
-    lateinit var spec: CommandLine.Model.CommandSpec
 
     override fun generate(projectFolder: File) {
 

--- a/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
@@ -35,8 +35,7 @@ class NewCommand : AbstractCommand(), Callable<Int> {
                 outputDir = projectFolder.path,
                 contracts = loadContractConfigurations(abis, bins),
                 addressLength = addressLength,
-                contextPath = projectOptions.contextPath?.removeSuffix("/") ?: projectOptions.projectName,
-                version = OpenApiCommand.VersionProvider.versionName
+                contextPath = projectOptions.contextPath?.removeSuffix("/") ?: projectOptions.projectName
         )
 
         GenerateOpenApi(generatorConfiguration).generateAll()

--- a/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/NewCommand.kt
@@ -12,10 +12,12 @@
  */
 package io.epirus.console.openapi
 
+import io.epirus.console.EpirusVersionProvider
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration
 import org.web3j.openapi.codegen.utils.GeneratorUtils.loadContractConfigurations
 import org.web3j.openapi.console.utils.GradleUtils.runGradleTask
+import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.io.File
 import java.util.concurrent.Callable
@@ -23,7 +25,15 @@ import java.util.concurrent.Callable
 @Command(
         name = "new",
         showDefaultValues = true,
-        description = ["Generates a whole Web3j OpenAPI project."]
+        description = ["Generates a whole OpenAPI project."],
+        abbreviateSynopsis = true,
+        mixinStandardHelpOptions = true,
+        versionProvider = EpirusVersionProvider::class,
+        synopsisHeading = "%n",
+        descriptionHeading = "%nDescription:%n%n",
+        optionListHeading = "%nOptions:%n",
+        footerHeading = "%n",
+        footer = ["Epirus CLI is licensed under the Apache License 2.0"]
 )
 class NewCommand : AbstractCommand(), Callable<Int> {
 

--- a/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
@@ -12,6 +12,7 @@
  */
 package io.epirus.console.openapi
 
+import io.epirus.console.EpirusVersionProvider
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.IVersionProvider
@@ -28,7 +29,7 @@ import java.util.concurrent.Callable
 @Command(
     name = "openapi",
     description = ["Generate an OpenAPI project"],
-    versionProvider = OpenApiCommand.VersionProvider::class,
+    versionProvider = EpirusVersionProvider::class,
     subcommands = [GenerateCommand::class, NewCommand::class],
     mixinStandardHelpOptions = true
 )
@@ -39,33 +40,6 @@ class OpenApiCommand : Callable<Int> {
 
     override fun call(): Int {
         throw ParameterException(spec.commandLine(), "Missing required sub-command (see below)")
-    }
-
-    object VersionProvider : IVersionProvider {
-
-        val versionName: String
-        val buildTimestamp: OffsetDateTime
-
-        private val timeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS O")
-
-        init {
-            val url = javaClass.classLoader.getResource("version.properties")
-                ?: throw IllegalStateException("No version.properties file found in the classpath.")
-
-            val properties = Properties().apply { load(url.openStream()) }
-
-            versionName = properties.getProperty("version")
-            buildTimestamp = properties.getProperty("timestamp").toLong().let {
-                Instant.ofEpochMilli(it).atOffset(ZoneOffset.UTC)
-            }
-        }
-
-        override fun getVersion(): Array<String> {
-            return arrayOf(
-                "Version: $versionName",
-                "Build timestamp: ${buildTimestamp.let { timeFormatter.format(it) }}"
-            )
-        }
     }
 
     companion object {

--- a/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable
     name = "openapi",
     description = ["Generate an OpenAPI project"],
     versionProvider = OpenApiCommand.VersionProvider::class,
-    subcommands = [GenerateCommand::class],
+    subcommands = [GenerateCommand::class, NewCommand::class],
     mixinStandardHelpOptions = true
 )
 class OpenApiCommand : Callable<Int> {

--- a/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
@@ -15,15 +15,9 @@ package io.epirus.console.openapi
 import io.epirus.console.EpirusVersionProvider
 import picocli.CommandLine
 import picocli.CommandLine.Command
-import picocli.CommandLine.IVersionProvider
 import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.ParameterException
 import picocli.CommandLine.Spec
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.util.Properties
 import java.util.concurrent.Callable
 
 @Command(

--- a/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
@@ -12,7 +12,6 @@
  */
 package io.epirus.console.openapi
 
-import io.epirus.console.EpirusVersionProvider
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Model.CommandSpec

--- a/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
+++ b/src/main/kotlin/io.epirus.console/openapi/OpenApiCommand.kt
@@ -23,7 +23,6 @@ import java.util.concurrent.Callable
 @Command(
     name = "openapi",
     description = ["Generate an OpenAPI project"],
-    versionProvider = EpirusVersionProvider::class,
     subcommands = [GenerateCommand::class, NewCommand::class],
     mixinStandardHelpOptions = true
 )

--- a/src/main/kotlin/io.epirus.console/token/subcommand/erc777/ERC777GeneratorService.kt
+++ b/src/main/kotlin/io.epirus.console/token/subcommand/erc777/ERC777GeneratorService.kt
@@ -81,8 +81,7 @@ class ERC777GeneratorService(private val erc777Config: ERC777Config) {
                             listOf(
                                     File(erc777Config.outputDir + File.separator + "build" + File.separator + erc777Config.tokenName + ".bin"))),
                     addressLength = 20,
-                    contextPath = erc777Config.tokenName,
-                    version = OpenApiCommand.VersionProvider.versionName
+                    contextPath = erc777Config.tokenName
             )
 
             File(erc777Config.outputDir +

--- a/src/main/kotlin/io.epirus.console/token/subcommand/erc777/ERC777GeneratorService.kt
+++ b/src/main/kotlin/io.epirus.console/token/subcommand/erc777/ERC777GeneratorService.kt
@@ -12,7 +12,6 @@
  */
 package io.epirus.console.token.subcommand.erc777
 
-import io.epirus.console.openapi.OpenApiCommand
 import io.epirus.console.project.templates.TemplateReader
 import org.web3j.openapi.codegen.GenerateOpenApi
 import org.web3j.openapi.codegen.config.GeneratorConfiguration

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.web3j.protocol" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,8 +7,6 @@
         </encoder>
     </appender>
 
-    <logger name="org.web3j.protocol" level="DEBUG"/>
-
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
Now we have two commands for `OpenAPI`:
- `New` :  which generates a whole project with its gradle files
- `Generate` : only generates the `Core` interfaces and their `Implementations`