### PR TITLE
Build docker image if it does exist on run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
     gradleVersion = "6.2"
     kotlinLoggin = "1.7.9"
     web3jEpirusVersion = '0.0.4'
+    dockerJavaVersion = '3.2.5'
 }
 
 
@@ -97,7 +98,8 @@ dependencies {
             'com.github.zafarkhaja:java-semver:0.9.0',
             'log4j:log4j:1.2.17',
             "org.gradle:gradle-tooling-api:$gradleVersion",
-            "io.github.microutils:kotlin-logging:$kotlinLoggin"
+            "io.github.microutils:kotlin-logging:$kotlinLoggin",
+            "com.github.docker-java:docker-java:$dockerJavaVersion"
 
 
     compile group: 'com.diogonunes', name: 'JCDP', version: '4.0.1'

--- a/src/main/java/io/epirus/console/docker/subcommands/DockerRunCommand.java
+++ b/src/main/java/io/epirus/console/docker/subcommands/DockerRunCommand.java
@@ -15,8 +15,13 @@ package io.epirus.console.docker.subcommands;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.core.DockerClientBuilder;
 import io.epirus.console.EpirusVersionProvider;
+import io.epirus.console.docker.DockerCommand;
 import io.epirus.console.docker.DockerOperations;
+import io.epirus.console.project.InteractiveOptions;
 import org.apache.commons.lang3.ArrayUtils;
 import picocli.CommandLine;
 
@@ -51,7 +56,24 @@ public class DockerRunCommand implements DockerOperations, Runnable {
 
     @Override
     public void run() {
-        String walletJson = null;
+
+        DockerClient dockerClient = DockerClientBuilder.getInstance().build();
+        ListContainersCmd listContainersCmd = dockerClient.listContainersCmd().withShowAll(true);
+
+        if (listContainersCmd.exec().stream().noneMatch(i -> i.getImage().equals("web3app"))) {
+            if (new InteractiveOptions()
+                    .userAnsweredYes(
+                            "It seems that no Docker container has yet been built. Would you like to build a Dockerized version of your app now?")) {
+                new CommandLine(new DockerCommand())
+                        .execute(
+                                "build",
+                                "-d",
+                                Paths.get(System.getProperty("user.dir"))
+                                        .toAbsolutePath()
+                                        .toString());
+            }
+        }
+
         if (walletPath == null) {
             walletPath = Paths.get(config.getDefaultWalletPath());
         }

--- a/src/main/java/io/epirus/console/project/InteractiveOptions.java
+++ b/src/main/java/io/epirus/console/project/InteractiveOptions.java
@@ -137,7 +137,7 @@ public class InteractiveOptions {
         return walletCredentials;
     }
 
-    private boolean userAnsweredYes(String message) {
+    public boolean userAnsweredYes(String message) {
         print(message);
         String answer = getUserInput();
         return answer.trim().isEmpty()


### PR DESCRIPTION
Current Epirus CLI doesn't automatically build a docker image if you try to run one first. This PR enables functionality to do so.